### PR TITLE
Refactor/use fake for parsing placeholders where possible

### DIFF
--- a/src/faker/address.js
+++ b/src/faker/address.js
@@ -1,10 +1,10 @@
 const data = require('../../data/address.json');
 
 function parseFormat(faker, format) {
-  return faker.Fake
-    .f(format.replace(/\{(\w+)\}/g, m => `{Address.${m.substring(1)}`))
-    .replace(/#/, faker.Number.between(1, 9))
-    .replace(/#/g, _ => faker.Number.between(0, 9));
+  const text = format
+    .replace(/\{(\w+)\}/g, m => `{Address.${m.substring(1)}`)
+    .replace(/#/, faker.Number.between(1, 9));
+  return faker.Fake.f(text);
 }
 
 export default class Address {

--- a/src/faker/address.js
+++ b/src/faker/address.js
@@ -1,6 +1,6 @@
 const data = require('../../data/address.json');
 
-function parseFormat(faker, format) {
+function parse(faker, format) {
   const text = format
     .replace(/\{(\w+)\}/g, m => `{Address.${m.substring(1)}`)
     .replace(/#/, faker.Number.between(1, 9));
@@ -14,23 +14,23 @@ export default class Address {
 
   city() {
     const format = this.faker.Random.element(data['cities']);
-    return parseFormat(this.faker, format);
+    return parse(this.faker, format);
   }
 
   streetName() {
     const format = this.faker.Random.element(data['streetNames']);
-    return parseFormat(this.faker, format);
+    return parse(this.faker, format);
   }
 
   streetAddress() {
     const format = this.faker.Random.element(data['streetAddresses']);
-    return parseFormat(this.faker, format);
+    return parse(this.faker, format);
   }
 
   secondaryAddress() {
     const prefix = this.faker.Random.element(data['secondaryAddressPrefixes']);
     const format = `${prefix} ###`;
-    return parseFormat(this.faker, format);
+    return parse(this.faker, format);
   }
 
   buildingNumber() {
@@ -41,7 +41,7 @@ export default class Address {
     const format = stateAbbreviation == ''
       ? this.faker.Random.element(data['postcodes'])
       : data['postcodeByState'][stateAbbreviation];
-    return parseFormat(this.faker, format);
+    return parse(this.faker, format);
   }
 
   zip(stateAbbreviation = '') {

--- a/src/faker/compass.js
+++ b/src/faker/compass.js
@@ -1,19 +1,8 @@
 const data = require('../../data/compass.json');
 
-function parse(compass, text) {
-  return text
-    .replace(/\{cardinal\}/, compass.cardinal())
-    .replace(/\{ordinal\}/, compass.ordinal())
-    .replace(/\{halfWind\}/, compass.halfWind())
-    .replace(/\{quarterWind\}/, compass.quarterWind())
-    .replace(/\{cardinalAbbreviation\}/, compass.cardinalAbbreviation())
-    .replace(/\{ordinalAbbreviation\}/, compass.ordinalAbbreviation())
-    .replace(/\{halfWindAbbreviation\}/, compass.halfWindAbbreviation())
-    .replace(/\{quarterWindAbbreviation\}/, compass.quarterWindAbbreviation())
-    .replace(/\{cardinalAzimuth\}/, compass.cardinalAzimuth())
-    .replace(/\{ordinalAzimuth\}/, compass.ordinalAzimuth())
-    .replace(/\{halfWindAzimuth\}/, compass.halfWindAzimuth())
-    .replace(/\{quarterWindAzimuth\}/, compass.quarterWindAzimuth());
+function parse(faker, format) {
+  const text = format.replace(/\{(\w+)\}/g, m => `{Compass.${m.substring(1)}`);
+  return faker.Fake.f(text);
 }
 
 export default class Compass {
@@ -22,7 +11,7 @@ export default class Compass {
   }
 
   direction() {
-    return parse(this, this.faker.Random.element(data['directions']));
+    return parse(this.faker, this.faker.Random.element(data['directions']));
   }
 
   cardinal() {
@@ -42,7 +31,7 @@ export default class Compass {
   }
 
   abbreviation() {
-    return parse(this, this.faker.Random.element(data['abbreviations']));
+    return parse(this.faker, this.faker.Random.element(data['abbreviations']));
   }
 
   cardinalAbbreviation() {
@@ -62,7 +51,7 @@ export default class Compass {
   }
 
   azimuth() {
-    return parse(this, this.faker.Random.element(data['azimuths']));
+    return parse(this.faker, this.faker.Random.element(data['azimuths']));
   }
 
   cardinalAzimuth() {

--- a/src/faker/fake.js
+++ b/src/faker/fake.js
@@ -1,4 +1,4 @@
-function parse(faker, match) {
+function parseModule(faker, match) {
   const v = match.replace(/[{}]/g, '').split('.');
   const module = v[0];
   const method = v[1];
@@ -24,6 +24,8 @@ export default class Fake {
       throw new Error('A string must be specified');
     }
 
-    return str.replace(/\{(\w+)\.(\w+)\}/g, m => parse(this.faker, m));
+    return str
+      .replace(/\{(\w+)\.(\w+)\}/g, m => parseModule(this.faker, m))
+      .replace(/#/g, _ => this.faker.Number.between(0, 9))
   }
 }

--- a/src/faker/hacker.js
+++ b/src/faker/hacker.js
@@ -1,13 +1,8 @@
 const data = require('../../data/hacker.json');
 
-function parse(hacker, format) {
-  return format
-    .replace(/\{abbreviation\}/g, hacker.abbreviation())
-    .replace(/\{adjective\}/g, hacker.adjective())
-    .replace(/\{noun\}/g, hacker.noun())
-    .replace(/\{verb\}/g, hacker.verb())
-    .replace(/\{ingverb\}/g, hacker.ingverb())
-    .replace(/^(\w)/, m => m[0].toUpperCase());
+function parse(faker, format) {
+  const text = format.replace(/\{(\w+)\}/g, m => `{Hacker.${m.substring(1)}`);
+  return faker.Fake.f(text).replace(/^(\w)/, m => m[0].toUpperCase());
 }
 
 export default class Hacker {
@@ -16,7 +11,7 @@ export default class Hacker {
   }
 
   saySomethingSmart() {
-    return parse(this, this.faker.Random.element(data['phrases']));
+    return parse(this.faker, this.faker.Random.element(data['phrases']));
   }
 
   abbreviation() {

--- a/test/faker/fake.spec.js
+++ b/test/faker/fake.spec.js
@@ -11,6 +11,11 @@ describe('Fake', () => {
       expect(Faker.Fake.f('{Name.firstName}')).to.eql('Bob');
     }));
 
+    it('parses hashes as numbers', sinonTest(function() {
+      this.stub(Faker.Number, 'between').withArgs(0, 9).returns(5);
+      expect(Faker.Fake.f('#-##-###-####')).to.eql('5-55-555-5555');
+    }));
+
     it('throws an error if no string specified', () => {
       expect(() => Faker.Fake.f()).to.throw('A string must be specified');
     });


### PR DESCRIPTION
Replaced lengthy `parse` and `parseFormat` code with calls to the `Fake` faker.